### PR TITLE
make timer logic more deterministic for auton

### DIFF
--- a/src/main/java/frc/robot/commands/autonomous/AutonAimAndShoot.java
+++ b/src/main/java/frc/robot/commands/autonomous/AutonAimAndShoot.java
@@ -66,7 +66,6 @@ public class AutonAimAndShoot extends CommandBase {
 	public void initialize() {
 		shootWhenReady = false;
 		timer = new Timer();
-		timer2 = new Timer();
 		timer.reset();
 		xCoords = new double[] {0,71,74,78,81.5,84,85.7,90,94,98,102.5,106.2,111,115,120,124,128,133,137,141.5,147,151,154,159,164.5,170,175,180,184,188,192,195,200,204,208,211,215.7,221,225,228};
 		shooterYCoords = new double[] {2160,2160,2190,2190,2190,2190,2240,2290,2290,2320,2345,2365,2385,2410,2440,2460,2480,2480,2495,2515,2580,2580,2610,2610,2650,2680,2660,2700,2680,2720,2720,2720,2720,2760,2780,2810,2830,2850,2850,2860};
@@ -77,29 +76,22 @@ public class AutonAimAndShoot extends CommandBase {
 	@Override
 	public void execute() {
 		if (turretVision.hasTargets()) {
-			// turret.setSetpoint(turret.getMeasurement() - turretVision.xAngle());
-
 			if (shootWhenReady) {
-				if (hood.atSetpoint() && flywheel.atSetpoint() /*&& turret.atSetpoint()*/) {
-					// shoot
-					
-					timer2.start();
-					
-					if (timer2.get() < .15){
+				if (hood.atSetpoint() && flywheel.atSetpoint()) {
+					// activate just the kicker to shoot first ball
+					if (timer.get() == 0) {
 						kicker.setMotors(1);
 					}
-					else {
-						kicker.stopMotors();
-						timer2.stop();
+
+					// start timer when the first ball has exited the shooter
+					if (!kicker.hasBall()) {
 						timer.start();
 					}
 
-					if (timer.get() > 2){
-						kicker.setMotors(1);
+					// shoot the second ball after a delay
+					if (timer.hasElapsed(2)) {
 						tower.setMotors(Constants.TOWER_SPEED);	
 					}
-					
-
 				}
 			} else {
 				driveTrain.arcadeDrive(0, -driveTrainPIDController.calculate(turretVision.xAngle(), -3));
@@ -141,21 +133,6 @@ public class AutonAimAndShoot extends CommandBase {
 				tower.stopMotors();
 			}
 		}
-		// else {
-		// if (turret.atLeftLimit()) {
-		// reverse = true;
-		// }
-		// else if (turret.atRightLimit()) {
-		// reverse = false;
-		// }
-		// if (reverse) {
-		// turret.setMotor(-(Constants.TURRET_SCAN_SPEED));
-		// }
-		// else {
-		// turret.setMotor(Constants.TURRET_SCAN_SPEED);
-		// }
-		// }
-
 	}
 
 	// Called once the command ends or is interrupted.


### PR DESCRIPTION
Don't use timer to try and time when the first ball has been launched. Just launch the first ball with the kicker and then wait until a ball is no longer detected and THEN start a timer for the delay before loading/shooting the second ball.